### PR TITLE
catch Internal Server Error

### DIFF
--- a/shibboleth_authenticator/views.py
+++ b/shibboleth_authenticator/views.py
@@ -166,7 +166,10 @@ def authorized(remote_app=None):
     except OneLogin_Saml2_Error:
         return abort(500)
     errors = []
-    auth.process_response()
+    try:
+        auth.process_response()
+    except:
+        return abort(400)
     errors = auth.get_errors()
     if len(errors) == 0 and auth.is_authenticated():
         if 'RelayState' in request.form:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -116,9 +116,16 @@ def test_authorized(views_fixture):
         # Invalid configuration of python3-saml
         _invalid__saml_configuration(app)
         resp = client.get(
-            url_for('shibboleth_authenticator.metadata', remote_app='idp')
+            url_for('shibboleth_authenticator.authorized', remote_app='idp')
         )
         assert resp.status_code == 500
+
+        # Valid configuration, no authorization response
+        _valid_configuration(app)
+        resp = client.get(
+            url_for('shibboleth_authenticator.authorized', remote_app='idp')
+        )
+        assert resp.status_code == 400
 
 
 def test_metadata(views_fixture):


### PR DESCRIPTION
In authorized view an Internal Server Error occured, when there was no authorization response.
Now, the user will see a Bad Request 400.