### PR TITLE
Fix CI test runs, docs, version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest>=2.8.3',
     'sphinx_rtd_theme>=0.2.4',
 ]
 
@@ -118,9 +118,11 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Development Status :: 4 - Beta',
+        'Development Status :: 3 - Alpha',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ history = open('CHANGES.md').read()
 tests_require = [
     'check-manifest>=0.35',
     'coverage>=4.0',
-    'invenio-accounts>=1.0.0b1',
+    'invenio-accounts>=1.0.0b3',
     'invenio-userprofiles>=1.0.0a9',
     'isort>=4.2.5',
     'pydocstyle>=1.1.1',
@@ -58,13 +58,13 @@ extras_require = {
         'Sphinx>=1.5.1',
     ],
     'mysql': [
-        'invenio-oauthclient[mysql]>=1.0.0a12',
+        'invenio-oauthclient[mysql]>=1.0.0a13',
     ],
     'postgresql': [
-        'invenio-oauthclient[postgresql]>=1.0.0a12',
+        'invenio-oauthclient[postgresql]>=1.0.0a13',
     ],
     'sqlite': [
-        'invenio-oauthclient[sqlite]>=1.0.0a12',
+        'invenio-oauthclient[sqlite]>=1.0.0a13',
     ],
     'tests': tests_require,
 }

--- a/shibboleth_authenticator/handlers.py
+++ b/shibboleth_authenticator/handlers.py
@@ -43,7 +43,13 @@ _datastore = LocalProxy(lambda: _security.datastore)
 #
 @oauth_error_handler
 def authorized_signup_handler(auth, remote=None, *args, **kwargs):
-    """Handle sign-in/up functionality.
+    """
+    Handle sign-in/up functionality.
+
+    Checks if user is already registered. If not registered, the function
+    registers a new user and authenticates the new user. If there already
+    exists a user object in the database, the user is only authenticated and
+    logged in.
 
     :param remote: The remote application.
     :param resp: The response.

--- a/shibboleth_authenticator/version.py
+++ b/shibboleth_authenticator/version.py
@@ -23,4 +23,4 @@ and parsed by ``setup.py``.
 """
 
 
-__version__ = '0.1a2'
+__version__ = '0.1a2dev18052017'


### PR DESCRIPTION
- version bump
- fix failing CI test run by using pytest=>2.8.3 (#20)
- add documentation in handlers.py