### PR TITLE
Use container based images on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ notifications:
 
 dist: trusty
 
-sudo: required
+sudo: false
 
 services:
   - mysql


### PR DESCRIPTION
- speedup build
- use container base trusty images (`sudo: false`)

closes #15 