### PR TITLE
Pin Flask-WTF to solve CSRF-validation problem with profiles subform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_requires = [
 install_requires = [
     'Flask>=0.11.1',
     'Flask-Login>=0.3.2',
-    'Flask-WTF>=0.13.1',
+    'Flask-WTF>=0.13.1,<0.14.0',
     'python3-saml>=1.2.6',
     'uritools>=1.0.1',
 ]

--- a/shibboleth_authenticator/handlers.py
+++ b/shibboleth_authenticator/handlers.py
@@ -22,8 +22,6 @@ from __future__ import absolute_import, print_function
 
 from flask import current_app, redirect, session
 from flask_login import current_user
-from werkzeug.local import LocalProxy
-
 from invenio_db import db
 from invenio_oauthclient.handlers import (get_session_next_url,
                                           oauth_error_handler,
@@ -31,6 +29,7 @@ from invenio_oauthclient.handlers import (get_session_next_url,
 from invenio_oauthclient.utils import (create_csrf_disabled_registrationform,
                                        fill_form, oauth_authenticate,
                                        oauth_get_user, oauth_register)
+from werkzeug.local import LocalProxy
 
 from .utils import disable_csrf, get_account_info
 

--- a/shibboleth_authenticator/utils.py
+++ b/shibboleth_authenticator/utils.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, print_function
 
 from flask import current_app
 from werkzeug.local import LocalProxy
+from wtforms.fields.core import FormField
 
 _security = LocalProxy(lambda: current_app.extensions['security'])
 

--- a/shibboleth_authenticator/utils.py
+++ b/shibboleth_authenticator/utils.py
@@ -47,3 +47,12 @@ def get_account_info(attributes, remote_app):
         external_id=external_id,
         external_method=remote_app,
     )
+
+
+def disable_csrf(form):
+    """Disable CSRF protection."""
+    form.csrf_enabled = False
+    for f in form:
+        if isinstance(f, FormField):
+            disable_csrf(f.form)
+    return form

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ from flask_mail import Mail
 from flask_menu import Menu as FlaskMenu
 from invenio_accounts import InvenioAccounts
 from invenio_db import InvenioDB, db
-from invenio_userprofiles import UserProfile
+from invenio_userprofiles import InvenioUserProfiles, UserProfile
+from invenio_userprofiles.views import blueprint_ui_init
 from sqlalchemy_utils.functions import (create_database, database_exists,
                                         drop_database)
 
@@ -105,6 +106,17 @@ def app(base_app):
 
 
 @pytest.fixture
+def userprofiles_app(app):
+    """Configure userprofiles module."""
+    app.config.update(
+        USERPROFILES_EXTEND_SECURITY_FORMS=True,
+    )
+    InvenioUserProfiles(app)
+    app.register_blueprint(blueprint_ui_init)
+    return app
+
+
+@pytest.fixture
 def models_fixture(app):
     """Flask app with example data used to test models."""
     with app.app_context():
@@ -153,6 +165,17 @@ def views_fixture(base_app):
     ShibbolethAuthenticator(base_app)
     base_app.register_blueprint(blueprint)
     return base_app
+
+
+@pytest.fixture
+def userprofiles_fixture(views_fixture):
+    """Fixture with userprofiles module."""
+    views_fixture.config.update(
+        USERPROFILES_EXTEND_SECURITY_FORMS=True,
+    )
+    InvenioUserProfiles(views_fixture)
+    views_fixture.register_blueprint(blueprint_ui_init)
+    return views_fixture
 
 
 @pytest.fixture


### PR DESCRIPTION
Subforms are added by e.g. invenio-userprofiles module. In this subform csrf-protection was still active. Use the legacy unprotect solution as long as there is no other solution found for Flask-WTF > 0.14.