### PR TITLE
Fix flaskwtf issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_requires = [
 install_requires = [
     'Flask>=0.11.1',
     'Flask-Login>=0.3.2',
-    'Flask-WTF>=0.13.1,<0.14.0',
+    'Flask-WTF>=0.13.1',
     'python3-saml>=1.2.6',
     'uritools>=1.0.1',
 ]

--- a/shibboleth_authenticator/handlers.py
+++ b/shibboleth_authenticator/handlers.py
@@ -31,7 +31,7 @@ from invenio_oauthclient.utils import (create_csrf_disabled_registrationform,
                                        oauth_get_user, oauth_register)
 from werkzeug.local import LocalProxy
 
-from .utils import disable_csrf, get_account_info
+from .utils import create_csrf_free_registrationform, get_account_info
 
 _security = LocalProxy(lambda: current_app.extensions['security'])
 
@@ -69,9 +69,7 @@ def authorized_signup_handler(auth, remote=None, *args, **kwargs):
         )
         if user is None:
             # Auto sign-up if user not found
-            form = create_csrf_disabled_registrationform()
-
-            disabled_csrf_form = disable_csrf(form)
+            disabled_csrf_form = create_csrf_free_registrationform()
 
             disabled_csrf_form = fill_form(
                 disabled_csrf_form,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ def userprofiles_app(app):
     """Configure userprofiles module."""
     app.config.update(
         USERPROFILES_EXTEND_SECURITY_FORMS=True,
+        WTF_CSRF_ENABLED=True,
     )
     InvenioUserProfiles(app)
     app.register_blueprint(blueprint_ui_init)
@@ -199,10 +200,10 @@ def valid_user_dict():
             email='test@hzdr.de',
             profile=dict(
                 full_name='Test Tester',
-                username='123456',
+                username='test123',
             ),
         ),
-        external_id='123456',
+        external_id='test123',
         external_method='hzdr',
     )
 
@@ -212,6 +213,6 @@ def valid_attributes():
     """Fixture for valid attributes."""
     return dict(
         email_mapping=['test@hzdr.de'],
-        id_mapping=['123456'],
+        id_mapping=['test123'],
         full_name_mapping=['Test Tester'],
     )


### PR DESCRIPTION
In the userprofiles subform CSRF protection was not properly disabled.
Now, the csrf_token is manually deleted and csrf protection deactivated.

Flask-WTF could thus be unpinned and we ware also compatible to version 0.14.2