### PR TITLE
Update automatic deployment to PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ jobs:
           user: "frust"
           password:
             secure: "OxdYuguDK4ZoVtuts1vTaFsWTwlMDMpdvmonOhxmI4OJDWyLv5KRWjO6nS8SRrGCZeaPBx1LWXO48BeRt0yeaRUnaRLVjkY8ex2sd326m3qL+O934yclLo4GkqYO2X0HBxa2O5JpCrvNgeqCIJ0cD1WVdsqg/qoevbXC7S56AkAK+5SZZcYn75aC3diSKvl5u/B3qpp2ytvvcPfVXjfcGLp1evGCzr549P8K+BEAesgL1o+9F/1pIHNUu6kKDpwFbat9P//vcBUqZvGuWi6L1/IkZtseAmr4uZcVAA5lgzJ4xmPHy0bIE05o2wk7d7dngUi9YDwa7StiqouB3u+puJnvQQuDPjwNIUEYlaMnOyZ8y2JppXioUihsksteGw96IRKuLjA1NtpuNx7mw7kyGde9sBHtHrud1tiBFkxS7dIT2BTs8Il20XIYUPrN2JeHUDtGegSNxQmOCO+x1KLrl9yGrVPsDU7cBpIhKJWnTEB3+YkoSq7dWAD80yunVmuBLJbFIXKAJmvlxzKNvzym/SjPSXObmVptK1kNCwQEg9pAq+xDF/oIAtJq+kW4rcSKf5TXLi71qTowTWvLNuUX+1vNPdwQgzQ5ffRLfMX6Rs/p1GvFz02ijbfiBH6P6pYiZJH4YMtufkirsSDosecCmRRj686w78Idgc9coUok49w="
+          distributions: "sdist bdist_wheel"
           on:
             tags: true
             if: tag =~ ^v

--- a/shibboleth_authenticator/version.py
+++ b/shibboleth_authenticator/version.py
@@ -23,4 +23,4 @@ and parsed by ``setup.py``.
 """
 
 
-__version__ = '0.1a7'
+__version__ = '0.1a8_dev20171102'


### PR DESCRIPTION
Add the distributions key to the deploy stage in `.travis.yml`. Add `bdist_wheel`-option.