### PR TITLE
Use csrf disable function from invenio-oauthclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ tests_require = [
     'check-manifest>=0.35',
     'coverage>=4.0',
     'invenio-accounts>=1.0.0b8',
-    'invenio-userprofiles>=1.0.0b1',
+    'invenio-userprofiles>=1.0.0b2',
     'isort>=4.2.5',
     'mock>=1.3.0',
     'pydocstyle>=1.1.1',
@@ -58,13 +58,13 @@ extras_require = {
         'Sphinx>=1.5.1',
     ],
     'mysql': [
-        'invenio-oauthclient[mysql]>=1.0.0b2',
+        'invenio-oauthclient[mysql]>=1.0.0b3',
     ],
     'postgresql': [
-        'invenio-oauthclient[postgresql]>=1.0.0b2',
+        'invenio-oauthclient[postgresql]>=1.0.0b3',
     ],
     'sqlite': [
-        'invenio-oauthclient[sqlite]>=1.0.0b2',
+        'invenio-oauthclient[sqlite]>=1.0.0b3',
     ],
     'tests': tests_require,
 }

--- a/shibboleth_authenticator/handlers.py
+++ b/shibboleth_authenticator/handlers.py
@@ -26,11 +26,12 @@ from invenio_db import db
 from invenio_oauthclient.handlers import (get_session_next_url,
                                           oauth_error_handler,
                                           token_session_key)
-from invenio_oauthclient.utils import (fill_form, oauth_authenticate,
+from invenio_oauthclient.utils import (create_csrf_disabled_registrationform,
+                                       fill_form, oauth_authenticate,
                                        oauth_get_user, oauth_register)
 from werkzeug.local import LocalProxy
 
-from .utils import create_csrf_free_registrationform, get_account_info
+from .utils import get_account_info
 
 _security = LocalProxy(lambda: current_app.extensions['security'])
 
@@ -68,14 +69,14 @@ def authorized_signup_handler(auth, remote=None, *args, **kwargs):
         )
         if user is None:
             # Auto sign-up if user not found
-            disabled_csrf_form = create_csrf_free_registrationform()
+            form = create_csrf_disabled_registrationform()
 
-            disabled_csrf_form = fill_form(
-                disabled_csrf_form,
+            form = fill_form(
+                form,
                 account_info['user']
             )
 
-            user = oauth_register(disabled_csrf_form)
+            user = oauth_register(form)
 
             # if registration fails ...
             if user is None:

--- a/shibboleth_authenticator/utils.py
+++ b/shibboleth_authenticator/utils.py
@@ -48,37 +48,3 @@ def get_account_info(attributes, remote_app):
         external_id=external_id,
         external_method=remote_app,
     )
-
-
-def registrationfrom_cls():
-    """Create a registration form."""
-    class RegistrationForm(_security.confirm_register_form):
-        password = None
-        recaptcha = None
-    return RegistrationForm
-
-
-def create_csrf_free_registrationform():
-    """Create CSRF disables registration form."""
-    form_cls = registrationfrom_cls()
-    form = disable_csrf(form_cls())
-    return form
-
-
-def disable_csrf(form):
-    """Disable CSRF protection."""
-    import flask_wtf
-    from pkg_resources import parse_version
-    if parse_version(flask_wtf.__version__) >= parse_version("0.14.0"):
-        form.meta.csrf = False
-        if hasattr(form, 'csrf_token'):
-            del form.csrf_token
-        for f in form:
-            if isinstance(f, FormField):
-                disable_csrf(f.form)
-    else:
-        form.csrf_enabled = False
-        for f in form:
-            if isinstance(f, FormField):
-                disable_csrf(f.form)
-    return form

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,16 +23,7 @@ import pytest
 from invenio_oauthclient.utils import fill_form
 
 from helpers import check_csrf_disabled
-from shibboleth_authenticator.utils import (create_csrf_free_registrationform,
-                                            get_account_info)
-
-
-def _attributes():
-    return dict(
-        email_mapping=['test@hzdr.de'],
-        id_mapping=['123456'],
-        full_name_mapping=['Test Tester'],
-    )
+from shibboleth_authenticator.utils import get_account_info
 
 
 def test_accountinfo(valid_user_dict, valid_attributes, models_fixture):
@@ -44,18 +35,3 @@ def test_accountinfo(valid_user_dict, valid_attributes, models_fixture):
     # Test invalid remote app.
     with pytest.raises(KeyError):
         res = get_account_info(valid_attributes, 'invalid')
-
-
-def test_csrf_disable(userprofiles_app, valid_user_dict):
-    """Test disabling of CSRF-Token."""
-    app = userprofiles_app
-    with app.test_request_context():
-        form = create_csrf_free_registrationform()
-
-        form = fill_form(
-            form,
-            valid_user_dict['user'],
-        )
-
-        check_csrf_disabled(form)
-        assert form.validate()


### PR DESCRIPTION
Invenio-oauthclient>=1.0.0b3 and invenio-userprofiles>=1.0.0b2 resolved the CSRF problem.

Updates the dependencies and uses csrf disable function from invenio-oauthclient.