### PR TITLE
utils: add get_safe_redirect_target function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Version 0.1.2.post
 
+- Fix get_safe_redirect_target function by not dropping the query parameters anymore [#48](https://github.com/tobiasfrust/shibboleth-authenticator/pull/48)
 - Bump Invenio dependencies to stable versions (> v1.0.0) [#47](https://github.com/tobiasfrust/shibboleth-authenticator/pull/47)
 
 Version 0.1.2

--- a/shibboleth_authenticator/views.py
+++ b/shibboleth_authenticator/views.py
@@ -24,13 +24,13 @@ from flask import (Blueprint, abort, current_app, make_response, redirect,
                    request)
 from flask_login import current_user, logout_user
 from invenio_oauthclient.handlers import set_session_next_url
-from invenio_oauthclient.utils import get_safe_redirect_target
 from itsdangerous import BadData, TimedJSONWebSignatureSerializer
 from onelogin.saml2.auth import OneLogin_Saml2_Auth, OneLogin_Saml2_Error
 from werkzeug.local import LocalProxy
 
 from ._compat import _create_identifier, urlparse
 from .handlers import authorized_signup_handler
+from .utils import get_safe_redirect_target
 
 blueprint = Blueprint(
     'shibboleth_authenticator',


### PR DESCRIPTION
- the function used from `invenio_oauthclient` drops the query parameters from the redirect target
- sort imports