### PR TITLE
depedencies: pin requests-oauthlib and oauthlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,9 @@ install_requires = [
     'Flask>=0.11.1',
     'Flask-Login>=0.3.2',
     'Flask-WTF>=0.13.1',
+    'oauthlib>=1.1.2,!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0',
     'python3-saml>=1.4.0',
+    'requests-oauthlib>=0.6.2,<1.2.0',
     'uritools>=1.0.1',
 ]
 


### PR DESCRIPTION
Version 3 of `oauthlib` was released quite a few days ago.

Flask-oauthlib has dependencies `oauthlib>=1.1.2,!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0`. `requests-oauthlib` and `oauthlib` need to be pinned.